### PR TITLE
Set response to /formatlogs to ephemeral. Fixes #2

### DIFF
--- a/disco-octopus/Program.cs
+++ b/disco-octopus/Program.cs
@@ -37,7 +37,7 @@ namespace disco_octopus
 
                     string pattern = @"(\[[^ ]*\])*<?([A-Z][a-z|'|-]* [A-Z][a-z|'|-]*)([A-Z][a-z]*)?>?(.*)";
                     string result = Regex.Replace(logs, pattern, "$2$4");
-                    await modal.RespondAsync(result);
+                    await modal.RespondAsync(result, ephemeral: true);
                 };
 
                 string token = Environment.GetEnvironmentVariable("DiscordBotToken") ?? "";


### PR DESCRIPTION
@Vertigeux So this is how we could set the /formatlogs response to only show for the person who issued the command; I'd suggest it might be a good idea just to keep it consistent with the other responses the bot gives out. I'll let you make the call about merging this or solving it another way. Maybe with a second modal button to allow a direct, non-ephemeral response?